### PR TITLE
Enhance Club Pages UI and Add Inactive Club Support

### DIFF
--- a/src/app/Student/Clubs/[slug]/ClubHero.js
+++ b/src/app/Student/Clubs/[slug]/ClubHero.js
@@ -56,13 +56,13 @@ const ClubHero = ({ club }) => {
   };
 
   return (
-    <div className="w-full space-y-8 py-6 px-4 sm:px-6 md:py-8 max-w-7xl mx-auto antialiased">
+    <div className="w-full space-y-8 antialiased">
       
       {/* OVERVIEW HERO SECTION */}
-      <section id="overview" className="relative overflow-hidden rounded-3xl border border-slate-200/60 bg-white p-6 sm:p-10 shadow-[0_4px_20px_-4px_rgba(0,0,0,0.02)] scroll-mt-24" >
-        <div className="relative z-10 flex flex-col lg:flex-row lg:items-start justify-between gap-6 lg:gap-8 max-w-6xl mx-auto">
-          <div className="flex flex-col items-center text-center lg:flex-row lg:items-start lg:text-left gap-5 sm:gap-6 flex-1 min-w-0">
-            <div className="relative rounded-full border border-slate-100 bg-white p-1 shadow-sm overflow-hidden bg-slate-50 h-20 w-20 sm:h-24 sm:w-24 shrink-0">
+      <section id="overview" className="relative overflow-hidden rounded-2xl border border-red-100 bg-white p-6 sm:p-8 shadow-sm scroll-mt-24" >
+        <div className="relative z-10 flex flex-col lg:flex-row lg:items-center justify-between gap-6 lg:gap-8 max-w-6xl mx-auto">
+          <div className="flex flex-col items-center text-center lg:flex-row lg:items-center lg:text-left gap-5 sm:gap-6 flex-1 min-w-0">
+            <div className="relative rounded-full border-2 border-red-200 bg-white p-1 shadow-sm overflow-hidden h-20 w-20 sm:h-24 sm:w-24 shrink-0">
               <img
                 src={club?.logo || Clubs.src}
                 alt={`${name} logo`}
@@ -72,8 +72,8 @@ const ClubHero = ({ club }) => {
               />
             </div>
 
-            <div className="space-y-2 min-w-0">
-              <h1 className="text-2xl font-black tracking-tight text-slate-900 sm:text-3xl md:text-4xl leading-tight">
+            <div className="space-y-1.5 min-w-0">
+              <h1 className="text-2xl font-extrabold tracking-tight text-red-950 sm:text-3xl leading-tight">
                 {name}
               </h1>
               <p className="text-xs sm:text-sm font-bold tracking-widest text-red-700 uppercase">
@@ -82,11 +82,11 @@ const ClubHero = ({ club }) => {
             </div>
           </div>
 
-          <div className="flex flex-col sm:flex-row items-center gap-3 w-full lg:w-auto shrink-0 justify-center lg:pt-2">
+          <div className="flex flex-col sm:flex-row items-center gap-3 w-full lg:w-auto shrink-0 justify-center">
             <Link
               href={clubId ? `/Student/Clubs/${clubId}/events` : "#"}
               aria-disabled={!clubId}
-              className={`group inline-flex w-full sm:w-auto items-center justify-center gap-2 rounded-xl bg-[rgb(129,25,25)] px-5 py-3 text-xs font-bold text-white transition-all duration-200 hover:bg-[rgb(100,18,18)] whitespace-nowrap ${
+              className={`group inline-flex w-full sm:w-auto items-center justify-center gap-2 rounded-xl bg-red-800 px-5 py-3 text-xs font-bold text-white transition-all duration-200 hover:bg-red-900 shadow-md hover:shadow-lg whitespace-nowrap ${
                 !clubId ? "pointer-events-none opacity-50" : ""
               }`}
             >
@@ -98,28 +98,28 @@ const ClubHero = ({ club }) => {
             <Link
               href={clubId ? `/Student/Clubs/${clubId}/team` : "#"}
               aria-disabled={!clubId}
-              className={`group inline-flex w-full sm:w-auto items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-5 py-3 text-xs font-bold text-slate-700 transition-all duration-200 hover:border-red-200 hover:bg-red-50/50 hover:text-red-700 whitespace-nowrap ${
+              className={`group inline-flex w-full sm:w-auto items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-5 py-3 text-xs font-bold text-red-900 transition-all duration-200 hover:border-red-300 hover:bg-red-50 hover:text-red-950 shadow-sm whitespace-nowrap ${
                 !clubId ? "pointer-events-none opacity-50" : ""
               }`}
             >
-              <Users className="h-4 w-4 text-slate-400 group-hover:text-red-600 transition-colors duration-200" />
+              <Users className="h-4 w-4 text-red-700/80 group-hover:text-red-900 transition-colors duration-200" />
               Meet Team
-              <ArrowRight className="h-3.5 w-3.5 text-slate-400 transition-transform duration-200 group-hover:translate-x-0.5" />
+              <ArrowRight className="h-3.5 w-3.5 text-red-700/80 transition-transform duration-200 group-hover:translate-x-0.5" />
             </Link>
           </div>
         </div>
 
         {/* Stats Summary Grid Footer */}
-        <div className="mt-10 pt-6 border-t border-slate-100 grid grid-cols-2 gap-3 min-[640px]:grid-cols-4">
+        <div className="mt-8 pt-6 border-t border-red-100 grid grid-cols-2 gap-3 min-[640px]:grid-cols-4">
           {stats.map((stat) => (
             <div
               key={stat.label}
-              className="bg-red-50/40 rounded-xl p-3 text-center border border-red-100/50"
+              className="bg-[#f7f5ec]/70 rounded-xl p-3 text-center border border-red-100/60 shadow-sm"
             >
-              <span className="block text-lg font-black text-red-900">
+              <span className="block text-lg font-extrabold text-red-900">
                 {stat.val}
               </span>
-              <span className="text-[10px] font-bold text-slate-500 tracking-wider uppercase mt-0.5 block">
+              <span className="text-[10px] font-bold text-red-950/60 tracking-wider uppercase mt-0.5 block">
                 {stat.label}
               </span>
             </div>
@@ -129,16 +129,16 @@ const ClubHero = ({ club }) => {
 
       {/* ABOUT CLUB BRIEF SECTION */}
       {club?.about?.trim() && (
-        <section id="about" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <span className="text-xs font-bold uppercase tracking-[0.2em] text-red-700">
+        <section id="about" className="space-y-4 scroll-mt-24">
+          <div className="flex items-center gap-2 pb-2 border-b border-red-100">
+            <span className="inline-block w-1.5 h-5 bg-red-700 rounded-full"></span>
+            <h2 className="text-base font-extrabold text-red-950 uppercase tracking-wider">
               About
-            </span>
-            <div className="h-px flex-1 bg-slate-200" />
+            </h2>
           </div>
 
-          <div className="rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm sm:p-7">
-            <p className="whitespace-pre-line text-sm leading-7 text-slate-600 md:text-base">
+          <div className="rounded-2xl border border-red-100/80 bg-white p-5 shadow-sm sm:p-6">
+            <p className="whitespace-pre-line text-sm leading-relaxed text-gray-800 md:text-base">
               {club.about.length > 240
                 ? `${club.about.slice(0, 240)}...`
                 : club.about}
@@ -148,7 +148,7 @@ const ClubHero = ({ club }) => {
               <Link
                 href={clubId ? `/Student/Clubs/${clubId}/about` : "#"}
                 aria-disabled={!clubId}
-                className={`inline-flex items-center gap-2 rounded-lg border border-red-100 bg-red-50 px-4 py-2 text-xs font-semibold text-red-700 transition-all duration-200 hover:border-red-200 hover:bg-red-100 hover:text-red-800 ${
+                className={`inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-xs font-bold text-red-800 transition-all duration-200 hover:border-red-300 hover:bg-red-100 hover:text-red-950 ${
                   !clubId ? "pointer-events-none opacity-50" : ""
                 }`}
               >
@@ -162,25 +162,25 @@ const ClubHero = ({ club }) => {
 
       {/* PI DESK LEADERSHIP MESSAGE */}
       {piMessage && (
-        <section id="leadership" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <span className="text-xs font-bold uppercase tracking-widest text-red-700">
+        <section id="leadership" className="space-y-4 scroll-mt-24">
+          <div className="flex items-center gap-2 pb-2 border-b border-red-100">
+            <span className="inline-block w-1.5 h-5 bg-red-700 rounded-full"></span>
+            <h2 className="text-base font-extrabold text-red-950 uppercase tracking-wider">
               PI Desk
-            </span>
-            <div className="h-px flex-1 bg-slate-100" />
+            </h2>
           </div>
 
-          <div className="relative overflow-hidden rounded-2xl border border-slate-200/60 bg-white p-5 sm:p-7 shadow-sm">
+          <div className="relative overflow-hidden rounded-2xl border border-red-100/80 bg-white p-5 sm:p-6 shadow-sm">
             <Quote
               className="absolute right-6 top-6 h-12 w-12 text-red-50"
               strokeWidth={1}
               aria-hidden="true"
             />
 
-            <div className="relative z-10 grid gap-5 md:grid-cols-[180px_1fr] items-start">
+            <div className="relative z-10 grid gap-5 md:grid-cols-[180px_1fr] items-center">
               {PI && (
-                <div className="flex flex-col items-center p-4 bg-red-50/40 rounded-xl border border-red-100/50 text-center w-full">
-                  <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white border border-red-200 shadow-sm overflow-hidden">
+                <div className="flex flex-col items-center p-4 bg-[#f7f5ec]/70 rounded-2xl border border-red-100/50 text-center w-full shadow-sm">
+                  <div className="relative flex h-20 w-20 items-center justify-center rounded-full bg-white border-2 border-red-200 shadow-sm overflow-hidden">
                     <img
                       src={PI.avatar || "/faculty.jpeg"}
                       alt={PI.name}
@@ -190,20 +190,20 @@ const ClubHero = ({ club }) => {
                     />
                   </div>
 
-                  <h3 className="mt-3 text-xs font-bold text-slate-800">
+                  <h3 className="mt-3 text-sm font-bold text-red-950">
                     {PI.name}
                   </h3>
-                  <p className="text-[10px] text-red-500 font-bold mt-0.5">
+                  <p className="text-xs font-semibold text-red-800 mt-0.5">
                     {PI.department || ""}
                   </p>
                 </div>
               )}
-              <div className="space-y-3">
-                <span className="inline-flex items-center rounded-full bg-red-50 px-2.5 py-0.5 text-[10px] font-bold text-red-800">
+              <div className="space-y-3 flex-1">
+                <span className="inline-flex items-center rounded-full bg-red-50 px-2.5 py-0.5 text-[10px] font-bold text-red-800 uppercase tracking-wider">
                   Message from PI
                 </span>
-                <blockquote className="border-l-2 border-red-200 pl-4">
-                  <p className="text-sm leading-relaxed text-slate-600 italic font-medium">
+                <blockquote className="border-l-4 border-red-700 pl-4 bg-red-50/10 py-3 pr-3 rounded-r-xl">
+                  <p className="text-sm leading-relaxed text-gray-800 italic font-medium">
                     {piMessage || ""}
                   </p>
                 </blockquote>
@@ -215,15 +215,15 @@ const ClubHero = ({ club }) => {
 
       {/* FULL-WIDTH RESPONSIVE IMAGES CAROUSEL */}
       {carouselImages.length > 0 && (
-        <section id="gallery" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <span className="text-xs font-bold uppercase tracking-widest text-red-700">
+        <section id="gallery" className="space-y-4 scroll-mt-24">
+          <div className="flex items-center gap-2 pb-2 border-b border-red-100">
+            <span className="inline-block w-1.5 h-5 bg-red-700 rounded-full"></span>
+            <h2 className="text-base font-extrabold text-red-950 uppercase tracking-wider">
               Club Gallery
-            </span>
-            <div className="h-px flex-1 bg-slate-100" />
+            </h2>
           </div>
 
-          <div className="relative group/carousel w-full rounded-2xl overflow-hidden shadow-sm border border-slate-200/60 bg-slate-50 aspect-[16/9] md:aspect-[21/9]">
+          <div className="relative group/carousel w-full rounded-2xl overflow-hidden shadow-sm border border-red-100 bg-slate-50 aspect-[16/9] md:aspect-[21/9]">
             <div
               ref={scrollRef}
               onScroll={handleScroll}
@@ -248,7 +248,7 @@ const ClubHero = ({ club }) => {
                 <button
                   onClick={() => scrollToIndex(Math.max(0, activeIndex - 1))}
                   disabled={activeIndex === 0}
-                  className="absolute left-4 top-1/2 -translate-y-1/2 p-2.5 rounded-full bg-white/90 backdrop-blur-sm text-slate-700 hover:bg-white shadow transition-all duration-200 disabled:opacity-0 pointer-events-auto opacity-0 group-hover/carousel:opacity-100"
+                  className="absolute left-4 top-1/2 -translate-y-1/2 p-2.5 rounded-full bg-white/90 backdrop-blur-sm text-red-800 hover:bg-white shadow transition-all duration-200 disabled:opacity-0 pointer-events-auto opacity-0 group-hover/carousel:opacity-100"
                   aria-label="Previous image"
                 >
                   <ChevronLeft className="h-5 w-5" />
@@ -256,7 +256,7 @@ const ClubHero = ({ club }) => {
                 <button
                   onClick={() => scrollToIndex(Math.min(carouselImages.length - 1, activeIndex + 1))}
                   disabled={activeIndex === carouselImages.length - 1}
-                  className="absolute right-4 top-1/2 -translate-y-1/2 p-2.5 rounded-full bg-white/90 backdrop-blur-sm text-slate-700 hover:bg-white shadow transition-all duration-200 disabled:opacity-0 pointer-events-auto opacity-0 group-hover/carousel:opacity-100"
+                  className="absolute right-4 top-1/2 -translate-y-1/2 p-2.5 rounded-full bg-white/90 backdrop-blur-sm text-red-800 hover:bg-white shadow transition-all duration-200 disabled:opacity-0 pointer-events-auto opacity-0 group-hover/carousel:opacity-100"
                   aria-label="Next image"
                 >
                   <ChevronRight className="h-5 w-5" />

--- a/src/app/Student/Clubs/[slug]/ClubHero.js
+++ b/src/app/Student/Clubs/[slug]/ClubHero.js
@@ -3,20 +3,27 @@
 import { useState, useRef } from "react";
 import Link from "next/link";
 import { ArrowRight, CalendarDays, Quote, Users, ChevronLeft, ChevronRight } from "lucide-react";
-import Clubs from "@/app/assets/images/clubs.svg";
+import NITPLogo from "@/app/assets/images/logo.png";
 
 const ClubHero = ({ club }) => {
   // Safe extraction of club data parameters and fallbacks
   const name = club?.name || "Club";
+  const isInactive = club?.status && club.status.toLowerCase() === "inactive";
   const clubId = club?.id;
   const memberSessions = club?.members && typeof club.members === "object" ? club.members : {};
-  const latestSessionKey = Object.keys(memberSessions)[0];
+  const sessionKeys = Object.keys(memberSessions).sort((a, b) => b.localeCompare(a));
+  const latestSessionKey = sessionKeys[0] || null;
   const currentMembers =
     (latestSessionKey && memberSessions[latestSessionKey]) ||
     Object.values(memberSessions).find((session) => session && typeof session === "object") ||
     {};
 
-  const PI = currentMembers.patna_campus_pi || currentMembers.bihta_campus_pi;
+  const patnaPI = currentMembers.patna?.pi;
+  const bihtaPI = currentMembers.bihta?.pi;
+  const showPatnaPI = patnaPI && patnaPI.name;
+  const showBihtaPI = bihtaPI && bihtaPI.name;
+  const hasPI = showPatnaPI || showBihtaPI;
+
   const activeMembers = club?.active_members || "0";
   const eventsOrganized = club?.events_organized || "0";
   const establishedYear = club?.established_year || "1999";
@@ -57,14 +64,24 @@ const ClubHero = ({ club }) => {
 
   return (
     <div className="w-full space-y-8 antialiased">
+      {isInactive && (
+        <div className="w-full bg-slate-50 border border-slate-200 rounded-2xl p-4 flex items-center gap-3 text-slate-700 shadow-sm animate-fadeIn">
+          <span className="font-bold uppercase tracking-wider text-[10px] bg-slate-200/60 border border-slate-300 rounded px-2.5 py-1 text-slate-500">
+            Inactive
+          </span>
+          <p className="text-xs sm:text-sm font-medium">
+            This student club is currently inactive. Past archives, legacy members, and details are shown for reference.
+          </p>
+        </div>
+      )}
       
       {/* OVERVIEW HERO SECTION */}
-      <section id="overview" className="relative overflow-hidden rounded-2xl border border-red-100 bg-white p-6 sm:p-8 shadow-sm scroll-mt-24" >
+      <section id="overview" className={`relative overflow-hidden rounded-2xl border bg-white p-6 sm:p-8 shadow-sm scroll-mt-24 ${isInactive ? "border-gray-200" : "border-red-100"}`} >
         <div className="relative z-10 flex flex-col lg:flex-row lg:items-center justify-between gap-6 lg:gap-8 max-w-6xl mx-auto">
           <div className="flex flex-col items-center text-center lg:flex-row lg:items-center lg:text-left gap-5 sm:gap-6 flex-1 min-w-0">
-            <div className="relative rounded-full border-2 border-red-200 bg-white p-1 shadow-sm overflow-hidden h-20 w-20 sm:h-24 sm:w-24 shrink-0">
+            <div className={`relative rounded-full border bg-white p-1 shadow-sm overflow-hidden h-20 w-20 sm:h-24 sm:w-24 shrink-0 ${isInactive ? "border-gray-300 filter grayscale opacity-75" : "border-red-200"}`}>
               <img
-                src={club?.logo || Clubs.src}
+                src={club?.logo || NITPLogo.src}
                 alt={`${name} logo`}
                 className="h-full w-full object-cover rounded-full aspect-square"
                 loading="eager"
@@ -73,9 +90,16 @@ const ClubHero = ({ club }) => {
             </div>
 
             <div className="space-y-1.5 min-w-0">
-              <h1 className="text-2xl font-extrabold tracking-tight text-red-950 sm:text-3xl leading-tight">
-                {name}
-              </h1>
+              <div className="flex flex-wrap items-center gap-2 justify-center lg:justify-start">
+                <h1 className="text-2xl font-extrabold tracking-tight text-red-950 sm:text-3xl leading-tight">
+                  {name}
+                </h1>
+                {isInactive && (
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-500 border border-gray-300">
+                    Inactive
+                  </span>
+                )}
+              </div>
               <p className="text-xs sm:text-sm font-bold tracking-widest text-red-700 uppercase">
                 {club?.tagline}
               </p>
@@ -177,25 +201,53 @@ const ClubHero = ({ club }) => {
               aria-hidden="true"
             />
 
-            <div className="relative z-10 grid gap-5 md:grid-cols-[180px_1fr] items-center">
-              {PI && (
-                <div className="flex flex-col items-center p-4 bg-[#f7f5ec]/70 rounded-2xl border border-red-100/50 text-center w-full shadow-sm">
-                  <div className="relative flex h-20 w-20 items-center justify-center rounded-full bg-white border-2 border-red-200 shadow-sm overflow-hidden">
-                    <img
-                      src={PI.avatar || "/faculty.jpeg"}
-                      alt={PI.name}
-                      className="h-full w-full object-cover rounded-full aspect-square"
-                      loading="lazy"
-                      onError={(e) => {e.currentTarget.src = "/faculty.jpeg"}}
-                    />
-                  </div>
-
-                  <h3 className="mt-3 text-sm font-bold text-red-950">
-                    {PI.name}
-                  </h3>
-                  <p className="text-xs font-semibold text-red-800 mt-0.5">
-                    {PI.department || ""}
-                  </p>
+            <div className={`relative z-10 grid gap-6 ${showPatnaPI && showBihtaPI ? "lg:grid-cols-[380px_1fr]" : "md:grid-cols-[180px_1fr]"} items-center`}>
+              {hasPI && (
+                <div className="flex flex-col sm:flex-row gap-4 justify-center items-stretch w-full">
+                  {showBihtaPI && (
+                    <div className="flex flex-col items-center p-4 bg-[#f7f5ec]/70 rounded-2xl border border-red-100/50 text-center flex-1 shadow-sm min-w-[160px] max-w-[190px]">
+                      <div className="relative flex h-20 w-20 items-center justify-center rounded-full bg-white border-2 border-red-200 shadow-sm overflow-hidden">
+                        <img
+                          src={bihtaPI.avatar || "/faculty.jpeg"}
+                          alt={bihtaPI.name}
+                          className="h-full w-full object-cover rounded-full aspect-square"
+                          loading="lazy"
+                          onError={(e) => {e.currentTarget.src = "/faculty.jpeg"}}
+                        />
+                      </div>
+                      <span className="mt-2 text-[9px] font-bold text-red-700/80 uppercase tracking-wide">
+                        Bihta Campus PI
+                      </span>
+                      <h3 className="mt-1 text-sm font-bold text-red-950 line-clamp-1">
+                        {bihtaPI.name}
+                      </h3>
+                      <p className="text-xs font-semibold text-red-800 mt-0.5 line-clamp-1">
+                        {bihtaPI.department || ""}
+                      </p>
+                    </div>
+                  )}
+                  {showPatnaPI && (
+                    <div className="flex flex-col items-center p-4 bg-[#f7f5ec]/70 rounded-2xl border border-red-100/50 text-center flex-1 shadow-sm min-w-[160px] max-w-[190px]">
+                      <div className="relative flex h-20 w-20 items-center justify-center rounded-full bg-white border-2 border-red-200 shadow-sm overflow-hidden">
+                        <img
+                          src={patnaPI.avatar || "/faculty.jpeg"}
+                          alt={patnaPI.name}
+                          className="h-full w-full object-cover rounded-full aspect-square"
+                          loading="lazy"
+                          onError={(e) => {e.currentTarget.src = "/faculty.jpeg"}}
+                        />
+                      </div>
+                      <span className="mt-2 text-[9px] font-bold text-red-700/80 uppercase tracking-wide">
+                        Patna Campus PI
+                      </span>
+                      <h3 className="mt-1 text-sm font-bold text-red-950 line-clamp-1">
+                        {patnaPI.name}
+                      </h3>
+                      <p className="text-xs font-semibold text-red-800 mt-0.5 line-clamp-1">
+                        {patnaPI.department || ""}
+                      </p>
+                    </div>
+                  )}
                 </div>
               )}
               <div className="space-y-3 flex-1">

--- a/src/app/Student/Clubs/[slug]/ClubSidebar.js
+++ b/src/app/Student/Clubs/[slug]/ClubSidebar.js
@@ -12,8 +12,8 @@ import Clubs from "@/app/assets/images/clubs.svg";
 const linkClass = (active) =>
   `flex items-center gap-3 px-4 py-3 rounded-xl font-bold text-sm transition-all duration-300 transform group relative tracking-wide ${
     active
-      ? "bg-[rgb(129,25,25)] text-white shadow-lg shadow-[rgba(129,25,25,0.25)] scale-[1.02] before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-1 before:bg-white/60 before:rounded-r"
-      : "text-slate-600 hover:text-[rgb(129,25,25)] hover:bg-[rgba(129,25,25,0.08)] border border-transparent hover:border-[rgba(129,25,25,0.15)] hover:translate-x-1"
+      ? "bg-gradient-to-r from-red-800 to-red-600 text-white shadow-md shadow-red-900/10 scale-[1.02] before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-1 before:bg-white/60 before:rounded-r"
+      : "text-red-950/80 hover:text-red-900 hover:bg-red-50/80 border border-transparent hover:border-red-100/50 hover:translate-x-1"
   }`;
   
 // Renders the club logo, name, and category (supports both mobile and desktop layouts)
@@ -25,7 +25,7 @@ function ClubHeader({ club, mobile = false }) {
   if (mobile) {
     return (
       <div className="flex items-center gap-3 min-w-0 text-left">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-slate-100 bg-white p-1 shadow-sm overflow-hidden bg-slate-50">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-red-100 bg-white p-1 shadow-sm overflow-hidden bg-slate-50">
           <img
             src={logoSrc}
             alt={`${name} logo`}
@@ -34,10 +34,10 @@ function ClubHeader({ club, mobile = false }) {
         </div>
 
         <div className="min-w-0">
-          <h3 className="text-sm font-black text-slate-800 tracking-tight leading-tight truncate">
+          <h3 className="text-sm font-extrabold text-red-950 tracking-tight leading-tight truncate">
             {name}
           </h3>
-          <p className="text-[11px] font-bold text-[rgb(129,25,25)] uppercase tracking-wider mt-0.5 truncate">
+          <p className="text-[11px] font-bold text-red-700 uppercase tracking-wider mt-0.5 truncate">
             {category}
           </p>
         </div>
@@ -46,9 +46,9 @@ function ClubHeader({ club, mobile = false }) {
   }
 
   return (
-    <div className="p-6 border-b border-slate-100 bg-gradient-to-b from-slate-50/50 to-transparent">
+    <div className="p-5 border-b border-red-100 bg-gradient-to-b from-red-50/30 to-transparent">
       <div className="flex flex-col items-center text-center">
-        <div className="flex h-16 w-16 items-center justify-center rounded-full border border-slate-200/80 bg-white p-1 shadow-sm mb-4 transition-transform duration-300 hover:scale-[1.03] overflow-hidden bg-slate-50">
+        <div className="relative flex h-20 w-20 items-center justify-center rounded-full border-2 border-red-200 bg-white p-1 shadow-sm mb-3 transition-transform duration-300 hover:scale-[1.03] overflow-hidden bg-slate-50">
           <img
             src={logoSrc}
             alt={`${name} logo`}
@@ -56,13 +56,13 @@ function ClubHeader({ club, mobile = false }) {
           />
         </div>
         
-        <h2 className="text-base font-black text-slate-800 tracking-tight max-w-[200px] line-clamp-2">
+        <h2 className="text-md font-extrabold text-red-950 tracking-tight max-w-[200px] line-clamp-2">
           {name}
         </h2>
 
-        <p className="mt-1 text-[11px] font-bold text-[rgb(129,25,25)] uppercase tracking-wider">
+        <span className="mt-1.5 inline-flex items-center rounded-full bg-red-50 px-2.5 py-0.5 text-[10px] font-bold text-red-800 uppercase tracking-wider">
           {category}
-        </p>
+        </span>
       </div>
     </div>
   );
@@ -88,7 +88,7 @@ function NavLinks({ links, onClick }) {
                 <Icon 
                   size={18} 
                   className={`transition-transform duration-300 shrink-0 ${
-                    active ? "scale-100 text-white" : "text-slate-400 group-hover:text-[rgb(129,25,25)] group-hover:scale-105"
+                    active ? "scale-100 text-white" : "text-red-700/60 group-hover:text-red-800 group-hover:scale-105"
                   }`} 
                 />
               )}
@@ -109,15 +109,15 @@ function MobileClubSidebar({ club, links }) {
     <div className="min-[767px]:hidden w-full mb-6">
       <button
         onClick={() => setOpen((prev) => !prev)}
-        className="w-full flex items-center justify-between p-3.5 bg-white border border-slate-200 rounded-2xl shadow-sm transition-all duration-200 active:scale-[0.99]"
+        className="w-full flex items-center justify-between p-3.5 bg-white border-2 border-red-200 rounded-xl shadow-sm transition-all duration-200 active:scale-[0.99]"
       >
         <ClubHeader club={club} mobile />
 
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-50 border border-slate-100 text-slate-400 ml-2">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-red-50 border border-red-100 text-red-800 ml-2">
           <ChevronDown
             size={16}
             className={`transition-transform duration-300 ${
-              open ? "rotate-180 text-[rgb(129,25,25)]" : ""
+              open ? "rotate-180 text-red-900" : ""
             }`}
           />
         </div>
@@ -130,7 +130,7 @@ function MobileClubSidebar({ club, links }) {
             : "max-h-0 opacity-0 pointer-events-none"
         }`}
       >
-        <div className="bg-white rounded-2xl shadow-md border border-slate-100 p-2.5">
+        <div className="bg-white rounded-xl shadow-md border border-red-100 p-2.5">
           <NavLinks
             links={links}
             onClick={() => setOpen(false)}
@@ -144,7 +144,7 @@ function MobileClubSidebar({ club, links }) {
 // Fixed, sticky sidebar layout for desktop screens (>= 768px)
 function DesktopClubSidebar({ club, links }) {
   return (
-    <aside className="hidden min-[767px]:flex min-[767px]:w-56 lg:w-64 h-[calc(100vh-2rem)] sticky top-4 border border-slate-200/60 bg-white shadow-sm rounded-lg flex-col overflow-hidden">
+    <aside className="hidden min-[767px]:flex min-[767px]:w-56 lg:w-64 border border-red-100 bg-white shadow-md rounded-xl flex-col overflow-hidden w-full">
       <ClubHeader club={club} />
 
       <nav className="flex-1 p-4 overflow-y-auto">

--- a/src/app/Student/Clubs/[slug]/ClubSidebar.js
+++ b/src/app/Student/Clubs/[slug]/ClubSidebar.js
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { useClub } from "./ClubProvider";
 import { ChevronDown, LayoutDashboard, Users2, Calendar, Contact2 } from "lucide-react";
 
-import Clubs from "@/app/assets/images/clubs.svg";
+import NITPLogo from "@/app/assets/images/logo.png";
 
 // Dynamic active/inactive Tailwind styles for sidebar links
 const linkClass = (active) =>
@@ -18,14 +18,15 @@ const linkClass = (active) =>
   
 // Renders the club logo, name, and category (supports both mobile and desktop layouts)
 function ClubHeader({ club, mobile = false }) {
-  const logoSrc = club?.logo || Clubs.src;
+  const logoSrc = club?.logo || NITPLogo.src;
   const name = club?.name || "Club";
   const category = club?.category || "Student Club";
+  const isInactive = club?.status && club.status.toLowerCase() === "inactive";
 
   if (mobile) {
     return (
       <div className="flex items-center gap-3 min-w-0 text-left">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-red-100 bg-white p-1 shadow-sm overflow-hidden bg-slate-50">
+        <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border bg-white p-1 shadow-sm overflow-hidden ${isInactive ? "border-gray-300 filter grayscale opacity-75" : "border-red-100"}`}>
           <img
             src={logoSrc}
             alt={`${name} logo`}
@@ -48,7 +49,7 @@ function ClubHeader({ club, mobile = false }) {
   return (
     <div className="p-5 border-b border-red-100 bg-gradient-to-b from-red-50/30 to-transparent">
       <div className="flex flex-col items-center text-center">
-        <div className="relative flex h-20 w-20 items-center justify-center rounded-full border-2 border-red-200 bg-white p-1 shadow-sm mb-3 transition-transform duration-300 hover:scale-[1.03] overflow-hidden bg-slate-50">
+        <div className={`relative flex h-20 w-20 items-center justify-center rounded-full border-2 bg-white p-1 shadow-sm mb-3 transition-transform duration-300 hover:scale-[1.03] overflow-hidden ${isInactive ? "border-gray-300 filter grayscale opacity-75" : "border-red-200"}`}>
           <img
             src={logoSrc}
             alt={`${name} logo`}

--- a/src/app/Student/Clubs/[slug]/contact/ClubContact.js
+++ b/src/app/Student/Clubs/[slug]/contact/ClubContact.js
@@ -64,7 +64,7 @@ const ClubContact = ({ club }) => {
       icon: Mail,
       button: "Send Email",
       brandBg: "group-hover:bg-red-50",
-      brandText: "group-hover:text-red-600",
+      brandText: "group-hover:text-red-800",
       brandHoverBorder: "hover:border-red-200",
       glowColor: "bg-red-500/10",
     },
@@ -74,10 +74,10 @@ const ClubContact = ({ club }) => {
       href: website,
       icon: Globe,
       button: "Explore Site",
-      brandBg: "group-hover:bg-slate-900",
+      brandBg: "group-hover:bg-red-800",
       brandText: "group-hover:text-white",
-      brandHoverBorder: "hover:border-slate-300",
-      glowColor: "bg-slate-900/5",
+      brandHoverBorder: "hover:border-red-200",
+      glowColor: "bg-red-500/5",
     },
   ];
 
@@ -95,8 +95,8 @@ const ClubContact = ({ club }) => {
   ];
 
   return (
-    <div className="w-full space-y-10 py-6 px-4 sm:px-6 md:py-8 max-w-7xl mx-auto antialiased">
-      <section className="relative overflow-hidden rounded-3xl border border-slate-200/60 bg-white p-6 sm:p-10 lg:p-12 shadow-[0_4px_20px_-4px_rgba(0,0,0,0.02)]">
+    <div className="w-full space-y-8 antialiased">
+      <section className="relative overflow-hidden rounded-2xl border border-red-100 bg-white p-5 sm:p-8 shadow-sm">
         <div className="absolute inset-0 pointer-events-none select-none overflow-hidden" aria-hidden="true">
           <div className="absolute -right-24 -top-24 h-72 w-72 rounded-full bg-red-500/5 blur-3xl" />
           <div className="absolute -left-24 -bottom-24 h-72 w-72 rounded-full bg-orange-400/5 blur-3xl" />
@@ -104,14 +104,13 @@ const ClubContact = ({ club }) => {
 
         <div className="relative z-10 grid gap-8 lg:grid-cols-12 items-start">
           <div className="lg:col-span-5 flex flex-col justify-center h-full space-y-4">
-            <div className="inline-flex items-center gap-1.5 self-start rounded-full bg-red-50 border border-red-100 px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-red-700">
-              <Sparkles className="h-3.5 w-3.5 text-red-500" aria-hidden="true" />
-              Get In Touch
+            <div className="flex items-center gap-2 pb-2 border-b border-red-100 w-full text-center sm:text-left">
+              <span className="inline-block w-1.5 h-5 bg-red-700 rounded-full"></span>
+              <h2 className="text-xl font-extrabold text-red-950 uppercase tracking-wider">
+                Connect With {name}
+              </h2>
             </div>
-            <h2 className="text-xl font-extrabold tracking-tight text-slate-900 sm:text-3xl leading-tight">
-              Connect With {name}
-            </h2>
-            <p className="text-sm leading-relaxed text-slate-500 font-normal max-w-md">
+            <p className="text-sm leading-relaxed text-gray-500 font-normal max-w-md">
               Whether you want to build cutting-edge systems, share creative projects, 
               or express yourself through cultural networks — find your community here.
             </p>
@@ -122,17 +121,17 @@ const ClubContact = ({ club }) => {
                 <ContactCard key={item.title} item={item} />
               ))}
             </div>
-            <div className="relative overflow-hidden rounded-2xl border border-slate-200/60 bg-white p-5 sm:p-6 shadow-sm w-full">
+            <div className="relative overflow-hidden rounded-2xl border border-red-100/80 bg-white p-5 sm:p-6 shadow-sm w-full">
               <div className="min-w-0">
-                <h3 className="text-sm font-bold text-slate-800 tracking-tight">
+                <h3 className="text-sm font-bold text-red-950 tracking-tight">
                   Follow Us
                 </h3>
-                <p className="text-xs text-slate-400 font-normal mt-0.5">
+                <p className="text-xs text-gray-500 font-normal mt-0.5">
                   Stay updated with real-time events, and ongoing showcases.
                 </p>
               </div>
 
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-4 pt-4 border-t border-slate-100 w-full">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-4 pt-4 border-t border-red-100/60 w-full">
                 {socialPlatforms.map((platform) => {
                   const PlatformIcon = platform.icon;
                   return (
@@ -141,7 +140,7 @@ const ClubContact = ({ club }) => {
                       href={platform.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={`flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50/60 p-3 text-xs font-semibold text-slate-700 transition-all duration-200 ${platform.color} group/btn min-w-0`}
+                      className={`flex items-center justify-between rounded-xl border border-red-100/50 bg-red-50/20 p-3 text-xs font-semibold text-red-900 transition-all duration-200 ${platform.color} group/btn min-w-0`}
                     >
                       <div className="flex items-center gap-2 min-w-0">
                         <PlatformIcon className="h-4 w-4 shrink-0 transition-transform duration-200 group-hover/btn:scale-110" />
@@ -157,9 +156,11 @@ const ClubContact = ({ club }) => {
         </div>
       </section>
       <section id="why-join" className="space-y-4">
-        <div className="flex items-center gap-3">
-          <span className="text-xs font-bold uppercase tracking-widest text-slate-400">Why Should You Join?</span>
-          <div className="h-px flex-1 bg-slate-100" />
+        <div className="flex items-center gap-2 pb-2 border-b border-red-100">
+          <span className="inline-block w-1.5 h-5 bg-red-700 rounded-full"></span>
+          <h3 className="text-base font-extrabold text-red-950 uppercase tracking-wider">
+            Why Should You Join?
+          </h3>
         </div>
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
           {universalHighlights.map((h, idx) => {
@@ -167,16 +168,16 @@ const ClubContact = ({ club }) => {
             return (
               <div 
                 key={idx} 
-                className="group relative overflow-hidden rounded-xl border border-slate-200/60 bg-white p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-slate-300"
+                className="group relative overflow-hidden rounded-2xl border border-red-100/40 bg-[#f7f5ec]/70 p-5 transition-all duration-300 hover:-translate-y-0.5 hover:border-red-200 hover:shadow-sm shadow-xs"
               >
                 <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${h.bg} transition-transform duration-200 group-hover:scale-105`}>
                   <IconComponent className="h-4 w-4" />
                 </div>
                 
-                <h3 className="mt-4 text-sm font-bold text-slate-800 tracking-tight">
+                <h3 className="mt-4 text-sm font-bold text-red-950 tracking-tight">
                   {h.label}
                 </h3>
-                <p className="mt-1 text-xs leading-relaxed text-slate-500/90 font-normal">
+                <p className="mt-1 text-xs leading-relaxed text-gray-500/90 font-normal">
                   {h.desc}
                 </p>
               </div>

--- a/src/app/Student/Clubs/[slug]/events/ClubEvents.js
+++ b/src/app/Student/Clubs/[slug]/events/ClubEvents.js
@@ -44,23 +44,20 @@ const ClubEvents = ({ clubEvents, club }) => {
   }, [selectedIndex]);
 
   return (
-    <section className="w-full px-4 py-4 sm:px-6">
-      <div className="overflow-hidden rounded-3xl border border-slate-200/80 bg-white p-4 sm:p-6 md:p-8">
+    <section className="w-full">
+      <div className="overflow-hidden rounded-2xl border border-red-100 bg-white p-5 sm:p-6 md:p-8 shadow-sm">
         
         {/* Header Section */}
-        <div className="relative z-10 flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-6 border-b border-slate-100">
-          <div className="flex flex-col sm:flex-row items-center sm:items-start text-center sm:text-left gap-4">
-            <div className="space-y-1">
-              <h1 className="text-2xl font-extrabold tracking-tight text-slate-900 sm:text-3xl">
-                {club?.name || "Club"} Events
-              </h1>
-
-              <p className="text-sm text-slate-500">
-                Explore the club's events, workshops, competitions, and
-                community initiatives.
-              </p>
-            </div>
+        <div className="flex flex-col gap-2 pb-4 border-b border-red-100/60 w-full text-center sm:text-left">
+          <div className="flex items-center gap-2 justify-center sm:justify-start">
+            <span className="inline-block w-1.5 h-5 bg-red-700 rounded-full"></span>
+            <h1 className="text-xl font-extrabold text-red-950">
+              {club?.name || "Club"} Events
+            </h1>
           </div>
+          <p className="text-xs text-gray-500">
+            Explore the club's events, workshops, competitions, and community initiatives.
+          </p>
         </div>
 
         {/* Events Grid / Empty State conditional wrapper */}
@@ -72,10 +69,10 @@ const ClubEvents = ({ clubEvents, club }) => {
                 onClick={() =>
                   router.push(`/Student/Clubs/${clubId}/events/${event.id}`)
                 }
-                className="group cursor-pointer flex flex-col overflow-hidden rounded-xl border border-slate-200/60 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:border-slate-300"
+                className="group cursor-pointer flex flex-col overflow-hidden rounded-2xl border border-red-100/80 bg-white transition-all duration-300 hover:-translate-y-0.5 hover:border-red-200 hover:shadow-md"
               >
                 {/* Event Poster Area */}
-                <div className="relative aspect-[4/3] w-full overflow-hidden bg-slate-50 border-b border-slate-100">
+                <div className="relative aspect-[4/3] w-full overflow-hidden bg-slate-50 border-b border-red-100/40">
                   <img
                     src={event.poster}
                     alt={event.title}
@@ -89,14 +86,14 @@ const ClubEvents = ({ clubEvents, club }) => {
                   <div className="absolute inset-0 bg-gradient-to-t from-slate-950/40 via-transparent to-transparent opacity-60 transition-opacity duration-200" />
 
                   <div className="absolute top-3 left-3">
-                    <span className="rounded-md bg-slate-900/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white backdrop-blur-sm border border-white/10">
+                    <span className="rounded-md bg-red-900/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white backdrop-blur-sm border border-white/10">
                       {event.category || "Event"}
                     </span>
                   </div>
 
                   <button
                     onClick={(e) => openPoster(e, index)}
-                    className="absolute bottom-3 right-3 flex h-7 w-7 items-center justify-center rounded-lg bg-white border border-slate-200 text-slate-500 shadow-sm backdrop-blur-sm transition-colors duration-200 hover:bg-slate-900 hover:text-white hover:border-slate-900"
+                    className="absolute bottom-3 right-3 flex h-7 w-7 items-center justify-center rounded-lg bg-white border border-red-100 text-red-800 shadow-sm backdrop-blur-sm transition-colors duration-200 hover:bg-red-900 hover:text-white hover:border-red-900"
                     title="Fullscreen Poster View"
                   >
                     <Maximize2 size={12} className="stroke-[2.5]" />
@@ -106,25 +103,25 @@ const ClubEvents = ({ clubEvents, club }) => {
                 {/* Event Meta Details Card */}
                 <div className="flex flex-col justify-between flex-1 p-5 space-y-4">
                   <div className="space-y-2">
-                    <h3 className="line-clamp-1 text-sm font-bold text-slate-800 transition-colors duration-200 tracking-tight">
+                    <h3 className="line-clamp-1 text-sm font-bold text-red-950 transition-colors duration-200 tracking-tight">
                       {event.title}
                     </h3>
-                    <p className="line-clamp-2 text-xs text-slate-700 leading-relaxed font-normal">
+                    <p className="line-clamp-2 text-xs text-gray-700 leading-relaxed font-normal">
                       {event.description}
                     </p>
                     
                     {/* Event Metadata (Duration & Venue) */}
                     {(event.duration || event.venue) && (
-                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-slate-500 font-medium pt-1">
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-gray-500 font-medium pt-1">
                         {event.duration && (
                           <div className="flex items-center gap-1">
-                            <Clock className="h-3.5 w-3.5 text-slate-400" />
+                            <Clock className="h-3.5 w-3.5 text-red-700/60" />
                             <span>{event.duration}</span>
                           </div>
                         )}
                         {event.venue && (
                           <div className="flex items-center gap-1">
-                            <MapPin className="h-3.5 w-3.5 text-slate-400" />
+                            <MapPin className="h-3.5 w-3.5 text-red-700/60" />
                             <span className="line-clamp-1">{event.venue}</span>
                           </div>
                         )}
@@ -132,7 +129,7 @@ const ClubEvents = ({ clubEvents, club }) => {
                     )}
                   </div>
 
-                  <div className="pt-3 border-t border-slate-100 flex items-center justify-between text-[10px] font-bold uppercase tracking-wider text-red-600">
+                  <div className="pt-3 border-t border-red-100/40 flex items-center justify-between text-[10px] font-bold uppercase tracking-wider text-red-800">
                     <span>View Details</span>
                     <ArrowRight className="h-3.5 w-3.5 transition-transform duration-200 group-hover:translate-x-0.5" />
                   </div>
@@ -142,15 +139,15 @@ const ClubEvents = ({ clubEvents, club }) => {
           </div>
         ) : (
           /* Empty State fallback view when no events exist */
-          <div className="mt-8 flex flex-col items-center justify-center rounded-xl p-8 text-center">
-            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-400">
+          <div className="mt-8 flex flex-col items-center justify-center rounded-xl p-8 text-center bg-[#f7f5ec]/50 border border-dashed border-red-200">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-red-50 text-red-800">
               <CalendarDays className="h-4 w-4" />
             </div>
-            <h2 className="text-sm font-bold tracking-tight text-slate-900">
+            <h2 className="text-sm font-bold tracking-tight text-red-950">
               Data Unavailable
             </h2>
 
-            <p className="mt-2 max-w-xs text-xs font-medium leading-relaxed text-slate-400">
+            <p className="mt-2 max-w-xs text-xs font-medium leading-relaxed text-gray-500">
               Event details will be available soon.
             </p>
           </div>

--- a/src/app/Student/Clubs/[slug]/events/[eventId]/page.js
+++ b/src/app/Student/Clubs/[slug]/events/[eventId]/page.js
@@ -7,7 +7,9 @@ import { getEvent } from "../../../services/clubService";
 import Loading from "@/app/Loading";
 
 export default function EventPage() {
-  const { eventId } = useParams();
+  const params = useParams();
+  console.log("[DEBUG] EventPage params:", params);
+  const { eventId } = params || {};
 
   const [event, setEvent] = useState(null);
   const [loading, setLoading] = useState(true);

--- a/src/app/Student/Clubs/[slug]/layout.js
+++ b/src/app/Student/Clubs/[slug]/layout.js
@@ -5,25 +5,25 @@ import { getClub } from "../services/clubService";
 
 const Layout = async ({ children, params }) => {
   const { slug } = await params;
+  console.log("[DEBUG] Layout called with slug:", slug);
   const club = await getClub(slug);
+  console.log("[DEBUG] Layout club result:", club ? `Success: ${club.name} (id: ${club.id})` : "Failed: null");
 
-  if (!club?.id) notFound();
+  if (!club?.id) {
+    console.log("[DEBUG] Club not found, calling notFound()");
+    notFound();
+  }
 
   return (
     <ClubProvider club={club}>
-      <div className="min-h-screen w-full bg-slate-50/40 font-sans antialiased">
-        <div className="w-full px-4 py-6 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-[260px_1fr] lg:grid-cols-[300px_1fr] items-start">
-            <aside className="w-full md:sticky md:top-6 z-10 shrink-0">
-              <ClubSidebar />
-            </aside>
+      <div className="mx-auto w-[min(1200px,calc(100%_-_32px))] bg-white/70 backdrop-blur-md rounded-2xl border border-red-100 p-5 md:p-8 my-6 md:my-10 shadow-md flex flex-col md:flex-row gap-6 md:gap-8 items-start min-h-[80vh] font-sans antialiased">
+        <aside className="w-full md:w-60 lg:w-64 shrink-0 md:sticky md:top-24 z-10">
+          <ClubSidebar />
+        </aside>
 
-            <main className="min-w-0 w-full">
-              {children}
-            </main>
-            
-          </div>
-        </div>
+        <main className="min-w-0 w-full flex-1">
+          {children}
+        </main>
       </div>
     </ClubProvider>
   );

--- a/src/app/Student/Clubs/[slug]/team/ClubTeam.js
+++ b/src/app/Student/Clubs/[slug]/team/ClubTeam.js
@@ -3,7 +3,7 @@
 import React, { useState, useMemo } from "react";
 import { History, Inbox, ChevronDown } from "lucide-react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
+import { faEnvelope, faPhone } from "@fortawesome/free-solid-svg-icons";
 
 const ClubTeam = ({ club }) => {
   const [isLegacyOpen, setIsLegacyOpen] = useState(false);
@@ -28,6 +28,7 @@ const ClubTeam = ({ club }) => {
         email: targetSession.patna_campus_pi?.email,
         department: targetSession.patna_campus_pi?.department,
         image: targetSession.patna_campus_pi?.avatar,
+        contact: targetSession.patna_campus_pi?.contact,
       },
       {
         role: "Bihta Campus PI",
@@ -35,6 +36,7 @@ const ClubTeam = ({ club }) => {
         email: targetSession.bihta_campus_pi?.email,
         department: targetSession.bihta_campus_pi?.department,
         image: targetSession.bihta_campus_pi?.avatar,
+        contact: targetSession.bihta_campus_pi?.contact,
       },
       {
         role: "President",
@@ -42,6 +44,7 @@ const ClubTeam = ({ club }) => {
         email: targetSession.president?.email,
         department: targetSession.president?.department,
         image: targetSession.president?.avatar,
+        contact: targetSession.president?.contact,
       },
       {
         role: "Secretary",
@@ -49,6 +52,7 @@ const ClubTeam = ({ club }) => {
         email: targetSession.secretary?.email,
         department: targetSession.secretary?.department,
         image: targetSession.secretary?.avatar,
+        contact: targetSession.secretary?.contact,
       },
     ].filter((m) => m.name);
   };
@@ -60,23 +64,22 @@ const ClubTeam = ({ club }) => {
     return (
       <div
         key={`${member.role}-${index}-${member.name}`}
-        className="w-full max-w-[310px] h-[350px] bg-white rounded-xl shadow-md hover:shadow-xl overflow-hidden transition-all duration-300 border border-gray-100 flex flex-col justify-between relative"
+        className="w-full max-w-[280px] h-[340px] bg-[#f7f5ec] rounded-2xl shadow-md hover:shadow-lg overflow-hidden transition-all duration-300 border border-red-100/40 flex flex-col justify-between relative p-5 items-center group"
       >
-
-        <div className="absolute top-0 left-1/2 transform -translate-x-1/2 w-3/4 h-7 bg-red-700 rounded-b-lg opacity-90 flex items-center justify-center z-10 px-2">
-          <span className="text-[10px] sm:text-[11px] font-bold uppercase tracking-wider text-white truncate">
+        <div className="absolute top-0 left-1/2 transform -translate-x-1/2 w-2/3 h-6 bg-red-800 rounded-b-lg flex items-center justify-center z-10 px-2 shadow-sm">
+          <span className="text-[9px] sm:text-[10px] font-bold uppercase tracking-wider text-white truncate">
             {member.role}
           </span>
         </div>
 
-        <div className="bg-gradient-to-b from-gray-50 to-white pt-10 pb-2 relative mt-2">
-          <div className="w-[130px] h-[130px] mx-auto relative">
-            <div className="absolute inset-0 rounded-full bg-white p-0.5">
-              <div className="w-full h-full rounded-full p-2 bg-red-100/30 backdrop-blur-sm border-2 border-red-400/40 shadow-md flex items-center justify-center overflow-hidden">
+        <div className="pt-5 pb-2 relative mt-2">
+          <div className="w-[120px] h-[120px] mx-auto relative">
+            <div className="absolute inset-0 rounded-full bg-white p-0.5 shadow-sm border border-red-100">
+              <div className="w-full h-full rounded-full bg-red-50 flex items-center justify-center overflow-hidden">
                 <img
                   src={member.image || "/faculty.jpeg"}
                   alt={member.name}
-                  className="w-full h-full object-cover rounded-full transition-all duration-500"
+                  className="w-full h-full object-cover rounded-full transition-transform duration-500 group-hover:scale-105"
                   loading="lazy"
                   onError={(e) => {
                     e.currentTarget.src = "/faculty.jpeg";
@@ -87,17 +90,17 @@ const ClubTeam = ({ club }) => {
           </div>
         </div>
 
-        <div className="text-black px-4 pb-5 pt-1 text-center flex-1 flex flex-col justify-between min-w-0">
-          <div className="min-w-0">
+        <div className="text-black text-center flex-1 flex flex-col justify-between min-w-0 w-full">
+          <div className="min-w-0 px-2 mt-2">
             <h3
-              className="text-base sm:text-lg font-bold text-gray-800"
+              className="text-sm sm:text-base font-extrabold text-red-950 truncate"
               title={member.name}
             >
               {member.name}
             </h3>
             {member.department && (
               <p
-                className="text-xs sm:text-sm font-semibold text-red-700 tracking-tight mt-0.5"
+                className="text-xs font-semibold text-red-800 tracking-tight mt-0.5 truncate"
                 title={member.department}
               >
                 {member.department}
@@ -105,49 +108,64 @@ const ClubTeam = ({ club }) => {
             )}
           </div>
 
-          {member.email && (
-            <div className="w-full px-2 mt-auto min-w-0">
+          <div className="w-full px-2 mt-auto pt-2.5 border-t border-red-100/40 space-y-1.5 min-w-0">
+            {member.email && (
               <a
                 href={`mailto:${member.email}`}
-                className="inline-flex items-center justify-center gap-2 text-xs sm:text-sm text-gray-600 hover:text-blue-600 transition-all duration-300 w-full"
+                className="inline-flex items-center justify-center gap-2 text-xs text-gray-700 hover:text-red-900 transition-all duration-300 w-full"
                 title={member.email}
               >
                 <FontAwesomeIcon
                   icon={faEnvelope}
-                  className="w-3.5 h-3.5 text-blue-500 shrink-0"
+                  className="w-3.5 h-3.5 text-red-700 shrink-0"
                 />
-                <span className="truncate block max-w-full">
+                <span className="truncate block max-w-full font-medium">
                   {member.email}
                 </span>
               </a>
-            </div>
-          )}
+            )}
+            {member.contact && (
+              <a
+                href={`tel:${member.contact}`}
+                className="inline-flex items-center justify-center gap-2 text-xs text-gray-700 hover:text-red-900 transition-all duration-300 w-full"
+                title={member.contact}
+              >
+                <FontAwesomeIcon
+                  icon={faPhone}
+                  className="w-3 h-3 text-red-700 shrink-0"
+                />
+                <span className="truncate block max-w-full font-medium">
+                  {member.contact}
+                </span>
+              </a>
+            )}
+          </div>
         </div>
       </div>
     );
   };
 
   return (
-    <section className="w-full px-4 py-4 sm:px-6">
-      <div className="overflow-hidden rounded-3xl border border-slate-200/80 bg-white p-4 sm:p-6 md:p-8">
-        <div className="flex flex-col sm:flex-row items-center sm:items-start text-center sm:text-left gap-4">
-          <div className="space-y-1">
-            <h1 className="text-2xl font-extrabold tracking-tight text-slate-900 sm:text-3xl">
+    <section className="w-full">
+      <div className="overflow-hidden rounded-2xl border border-red-100 bg-white p-5 sm:p-6 md:p-8 shadow-sm">
+        <div className="flex flex-col gap-2 pb-4 border-b border-red-100/60 w-full text-center sm:text-left">
+          <div className="flex items-center gap-2 justify-center sm:justify-start">
+            <span className="inline-block w-1.5 h-5 bg-red-700 rounded-full"></span>
+            <h1 className="text-xl font-extrabold text-red-950">
               Members of {club?.name || "Club"}
             </h1>
-
-            <p className="text-sm text-slate-500">
-              Faculty mentors and student leaders driving our club forward.
-            </p>
           </div>
+          <p className="text-xs text-gray-500">
+            Faculty mentors and student leaders driving our club forward.
+          </p>
         </div>
         <div className="mt-8 space-y-4">
           {currentMembers.length === 0 ? (
-            <div className="flex min-h-[140px] flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 p-6 text-center">
-              <h3 className="text-xs font-bold text-slate-800">
+            <div className="flex min-h-[140px] flex-col items-center justify-center rounded-xl border border-dashed border-red-200 p-6 text-center">
+              <h3 className="text-xs font-bold text-red-950">
                 Nothing to Show
               </h3>
-              <p className="text-[11px] text-slate-500 max-w-xs mt-0.5">
+              <p className="text-[11px] text-gray-500 max-w-xs mt-0.5">
                 No member details available at this moment.
               </p>
             </div>
@@ -158,18 +176,18 @@ const ClubTeam = ({ club }) => {
           )}
         </div>
         {legacySessionKeys.length > 0 && (
-          <div className="mt-10 pt-6 border-t border-slate-100 space-y-4">
+          <div className="mt-10 pt-6 border-t border-red-100 space-y-4">
             <div className="flex items-center justify-between gap-4">
               <button
                 type="button"
                 onClick={() => setIsLegacyOpen((prev) => !prev)}
-                className="flex items-center gap-2.5 text-slate-400 hover:text-slate-600 transition-colors text-left"
+                className="flex items-center gap-2.5 text-slate-400 hover:text-red-900 transition-colors text-left"
               >
-                <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-slate-50 text-slate-500 border border-slate-200">
+                <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-red-50 text-red-800 border border-red-200 shadow-sm">
                   <History size={13} />
                 </div>
                 <div>
-                  <h2 className="text-xs font-bold uppercase tracking-wide text-slate-800">
+                  <h2 className="text-xs font-bold uppercase tracking-wide text-red-950">
                     Legacy Team
                   </h2>
                 </div>
@@ -178,7 +196,7 @@ const ClubTeam = ({ club }) => {
               <button
                 type="button"
                 onClick={() => setIsLegacyOpen((prev) => !prev)}
-                className={`flex h-7 w-7 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-400 hover:text-slate-600 transition-transform duration-300 ${
+                className={`flex h-7 w-7 items-center justify-center rounded-lg border border-red-200 bg-white text-red-800 hover:bg-red-50 hover:text-red-900 transition-transform duration-300 ${
                   isLegacyOpen ? "rotate-180" : ""
                 }`}
               >
@@ -189,7 +207,7 @@ const ClubTeam = ({ club }) => {
             {isLegacyOpen && (
               <div className="animate-fadeIn space-y-6">
                 <div className="flex flex-col items-center gap-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-800">
                     Select Session
                   </p>
 
@@ -198,7 +216,7 @@ const ClubTeam = ({ club }) => {
                       id="legacy-year-select"
                       value={selectedLegacyYear}
                       onChange={(e) => setSelectedLegacyYear(e.target.value)}
-                      className="w-full appearance-none rounded-xl border border-slate-200 bg-white py-3 pl-4 pr-10 text-sm font-semibold text-slate-700 shadow-sm transition-all duration-200 hover:border-slate-300 focus:border-red-300 focus:outline-none focus:ring-4 focus:ring-red-50"
+                      className="w-full appearance-none rounded-xl border border-red-200 bg-white py-2.5 pl-4 pr-10 text-sm font-semibold text-red-950 shadow-sm transition-all duration-200 hover:border-red-300 focus:border-red-500 focus:outline-none focus:ring-4 focus:ring-red-50"
                     >
                       {legacySessionKeys.map((year) => (
                         <option key={year} value={year}>
@@ -206,7 +224,7 @@ const ClubTeam = ({ club }) => {
                         </option>
                       ))}
                     </select>
-                    <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                    <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-red-800" />
                   </div>
                 </div>
 
@@ -217,9 +235,9 @@ const ClubTeam = ({ club }) => {
                     )}
                   </div>
                 ) : (
-                  <div className="flex min-h-[140px] flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 p-6 text-center">
-                    <Inbox className="h-5 w-5 text-slate-300" />
-                    <p className="text-[11px] text-slate-400 mt-1">
+                  <div className="flex min-h-[140px] flex-col items-center justify-center rounded-xl border border-dashed border-red-200 p-6 text-center">
+                    <Inbox className="h-5 w-5 text-red-700" />
+                    <p className="text-[11px] text-red-800/60 mt-1">
                       No records found for selected Session.
                     </p>
                   </div>

--- a/src/app/Student/Clubs/[slug]/team/ClubTeam.js
+++ b/src/app/Student/Clubs/[slug]/team/ClubTeam.js
@@ -21,44 +21,66 @@ const ClubTeam = ({ club }) => {
     if (!club?.members || !sessionKey || !club.members[sessionKey]) return [];
     const targetSession = club.members[sessionKey];
 
-    return [
-      {
-        role: "Patna Campus PI",
-        name: targetSession.patna_campus_pi?.name,
-        email: targetSession.patna_campus_pi?.email,
-        department: targetSession.patna_campus_pi?.department,
-        image: targetSession.patna_campus_pi?.avatar,
-        contact: targetSession.patna_campus_pi?.contact,
-      },
-      {
-        role: "Bihta Campus PI",
-        name: targetSession.bihta_campus_pi?.name,
-        email: targetSession.bihta_campus_pi?.email,
-        department: targetSession.bihta_campus_pi?.department,
-        image: targetSession.bihta_campus_pi?.avatar,
-        contact: targetSession.bihta_campus_pi?.contact,
-      },
-      {
-        role: "President",
-        name: targetSession.president?.name,
-        email: targetSession.president?.email,
-        department: targetSession.president?.department,
-        image: targetSession.president?.avatar,
-        contact: targetSession.president?.contact,
-      },
-      {
-        role: "Secretary",
-        name: targetSession.secretary?.name,
-        email: targetSession.secretary?.email,
-        department: targetSession.secretary?.department,
-        image: targetSession.secretary?.avatar,
-        contact: targetSession.secretary?.contact,
-      },
-    ].filter((m) => m.name);
+    const ROLE_MAP = {
+      pi: "Program Officer (PI)",
+      president: "President",
+      vice_president: "Vice President",
+      secretary: "Secretary",
+      joint_secretary_1: "Joint Secretary 1",
+      joint_secretary_2: "Joint Secretary 2",
+      coordinator_1: "Coordinator 1",
+      coordinator_2: "Coordinator 2"
+    };
+
+    const membersList = [];
+
+    const getCampusMembers = (campusKey, campusLabel) => {
+      const campusData = targetSession[campusKey];
+      if (campusData && typeof campusData === "object") {
+        Object.keys(ROLE_MAP).forEach((roleKey) => {
+          const m = campusData[roleKey];
+          if (m && m.name && m.name.trim() !== "") {
+            membersList.push({
+              role: ROLE_MAP[roleKey],
+              name: m.name,
+              email: m.email,
+              department: m.department,
+              image: m.avatar,
+              contact: m.contact,
+              campus: campusLabel,
+            });
+          }
+        });
+      }
+    };
+
+    getCampusMembers("bihta", "Bihta Campus");
+    getCampusMembers("patna", "Patna Campus");
+
+    return membersList;
   };
 
   const currentMembers = extractMembersFromSession(currentSessionKey);
   const legacyMembers = extractMembersFromSession(selectedLegacyYear);
+
+  const patnaCurrent = currentMembers.filter(m => m.campus === "Patna Campus");
+  const bihtaCurrent = currentMembers.filter(m => m.campus === "Bihta Campus");
+  const patnaLegacy = legacyMembers.filter(m => m.campus === "Patna Campus");
+  const bihtaLegacy = legacyMembers.filter(m => m.campus === "Bihta Campus");
+
+  const renderCampusSection = (campusLabel, membersList) => {
+    if (membersList.length === 0) return null;
+    return (
+      <div className="space-y-4">
+        <h3 className="text-sm font-extrabold uppercase tracking-widest text-red-800 border-b border-red-100 pb-2">
+          {campusLabel}
+        </h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 justify-items-center w-full">
+          {membersList.map((member, index) => MemberCard(member, index))}
+        </div>
+      </div>
+    );
+  };
 
   const MemberCard = (member, index) => {
     return (
@@ -159,7 +181,7 @@ const ClubTeam = ({ club }) => {
             Faculty mentors and student leaders driving our club forward.
           </p>
         </div>
-        <div className="mt-8 space-y-4">
+        <div className="mt-8 space-y-8">
           {currentMembers.length === 0 ? (
             <div className="flex min-h-[140px] flex-col items-center justify-center rounded-xl border border-dashed border-red-200 p-6 text-center">
               <h3 className="text-xs font-bold text-red-950">
@@ -170,9 +192,10 @@ const ClubTeam = ({ club }) => {
               </p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 justify-items-center w-full">
-              {currentMembers.map((member, index) => MemberCard(member, index))}
-            </div>
+            <>
+              {renderCampusSection("Bihta Campus", bihtaCurrent)}
+              {renderCampusSection("Patna Campus", patnaCurrent)}
+            </>
           )}
         </div>
         {legacySessionKeys.length > 0 && (
@@ -229,10 +252,9 @@ const ClubTeam = ({ club }) => {
                 </div>
 
                 {legacyMembers.length > 0 ? (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 justify-items-center w-full">
-                    {legacyMembers.map((member, index) =>
-                      MemberCard(member, index),
-                    )}
+                  <div className="space-y-8">
+                    {renderCampusSection("Bihta Campus", bihtaLegacy)}
+                    {renderCampusSection("Patna Campus", patnaLegacy)}
                   </div>
                 ) : (
                   <div className="flex min-h-[140px] flex-col items-center justify-center rounded-xl border border-dashed border-red-200 p-6 text-center">

--- a/src/app/Student/Clubs/page.js
+++ b/src/app/Student/Clubs/page.js
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { getClubs } from "./services/clubService";
+import NITPLogo from "@/app/assets/images/logo.png";
 
 export default async function ClubsPage({ searchParams }) {
   const params = await searchParams;
@@ -63,26 +64,38 @@ export default async function ClubsPage({ searchParams }) {
         aria-label="Club list"
       >
         {displayedClubs.length > 0 ? (
-          displayedClubs.map((club) => (
-            <Link
-              key={club.id}
-              href={`/Student/Clubs/${club.id}`}
-              className="mx-auto flex min-h-[180px] w-full max-w-[300px] flex-col items-center justify-center gap-4 rounded-lg border border-red-900/15 bg-white/85 px-[14px] py-[2px] text-center no-underline shadow-[0_14px_34px_rgba(127,29,29,0.08)] transition hover:-translate-y-1 hover:border-red-900/35 hover:shadow-[0_20px_42px_rgba(127,29,29,0.14)] md:mx-0 md:min-h-[158px] md:max-w-none md:px-3 md:py-[18px]"
-            >
-              <span className="grid h-[86px] w-[86px] place-items-center rounded-lg bg-[linear-gradient(145deg,#ffffff,#fff1f1)] shadow-[inset_0_0_0_6px_rgba(255,255,255,0.75)]">
-                <img
-                  src={club.logo || "/images/default-club.png"}
-                  alt={`${club.name} logo`}
-                  loading="lazy"
-                  className="h-[70px] w-[70px] rounded-[7px] object-cover"
-                />
-              </span>
+          displayedClubs.map((club) => {
+            const isInactive = club.status && club.status.toLowerCase() === "inactive";
+            return (
+              <Link
+                key={club.id}
+                href={`/Student/Clubs/${club.id}`}
+                className={`mx-auto flex min-h-[180px] w-full max-w-[300px] flex-col items-center justify-center gap-4 rounded-lg border px-[14px] py-[2px] text-center no-underline transition md:mx-0 md:min-h-[158px] md:max-w-none md:px-3 md:py-[18px] relative overflow-hidden ${
+                  isInactive
+                    ? "border-gray-200 bg-gray-50/80 opacity-70 filter grayscale shadow-sm hover:opacity-90 hover:border-gray-300"
+                    : "border-red-900/15 bg-white/85 shadow-[0_14px_34px_rgba(127,29,29,0.08)] hover:-translate-y-1 hover:border-red-900/35 hover:shadow-[0_20px_42px_rgba(127,29,29,0.14)]"
+                }`}
+              >
+                {isInactive && (
+                  <div className="absolute top-2 right-2 rounded bg-gray-500/10 px-1.5 py-0.5 text-[9px] font-bold text-gray-500 uppercase tracking-wider border border-gray-500/20">
+                    Inactive
+                  </div>
+                )}
+                <span className="grid h-[86px] w-[86px] place-items-center rounded-lg bg-[linear-gradient(145deg,#ffffff,#fff1f1)] shadow-[inset_0_0_0_6px_rgba(255,255,255,0.75)]">
+                  <img
+                    src={club.logo || NITPLogo.src}
+                    alt={`${club.name} logo`}
+                    loading="lazy"
+                    className="h-[70px] w-[70px] rounded-[7px] object-cover"
+                  />
+                </span>
 
-              <span className="text-base font-black leading-[1.35] text-gray-900">
-                {club.name}
-              </span>
-            </Link>
-          ))
+                <span className="text-base font-black leading-[1.35] text-gray-900">
+                  {club.name}
+                </span>
+              </Link>
+            );
+          })
         ) : (
           <div className="col-span-full py-10 text-center text-red-600 font-semibold text-xl">
             No clubs found in this category.

--- a/src/app/components/global/Navbar.jsx
+++ b/src/app/components/global/Navbar.jsx
@@ -779,11 +779,14 @@ export default function Navbar() {
           const clubs = await getClubs();
           if (mounted || !Array.isArray(clubs) || clubs.length === 0) return;
   
-          const clubChildren = clubs.map(club => ({
-            label: club.name,
-            link:  `/Student/Clubs/${club.id}`,
-            iconImage: club.logo || "",
-          }));
+          const clubChildren = clubs.map(club => {
+            const isInactive = club.status && club.status.toLowerCase() === "inactive";
+            return {
+              label: isInactive ? `${club.name} (Inactive)` : club.name,
+              link:  `/Student/Clubs/${club.id}`,
+              iconImage: club.logo || logo,
+            };
+          });
   
           setNavItems(buildNavItems(clubChildren));
         } catch (err) {


### PR DESCRIPTION
# Club Pages UI Enhancements & Inactive Club Support

## Summary

This PR combines UI improvements across the Clubs module with support for inactive clubs. It enhances the overall user experience, improves team member rendering, and adds clear visual indicators for inactive clubs while preserving legacy information.

## Changes

### UI Improvements
- Refined the club pages with a cleaner, more consistent design.
- Updated the color palette, typography, spacing, and component styling.
- Improved section headers, cards, buttons, and overall layout.
- Enhanced the sidebar, events, contact, team, and event detail pages for better visual consistency.

### Inactive Club Support
- Added support for `club.status === "inactive"`.
- Displayed an **Inactive** badge and informational banner.
- Applied grayscale styling to inactive club logos, cards, and sidebar.
- Updated the default club logo fallback to **NITPLogo**.

### Team & Data Improvements
- Fixed campus-wise PI rendering by displaying separate **Patna** and **Bihta** PIs.
- Replaced hardcoded role handling with a reusable `ROLE_MAP`.
- Grouped team members by campus for both current and legacy sessions.
- Improved latest session selection for more reliable data display.

## Impact

- Provides a cleaner and more consistent Clubs UI.
- Clearly distinguishes inactive clubs while preserving historical data.
- Improves team member organization and campus-wise representation.
- Enhances the overall reliability and user experience of the Clubs module.