### PR TITLE
fix(mobile-menu): add missing height={20} width={20} to submenu icons

### DIFF
--- a/src/app/components/global/Navbar.jsx
+++ b/src/app/components/global/Navbar.jsx
@@ -1124,7 +1124,7 @@ function SubSidemenu({ item, closeSideMenu }) {
               {subChild.iconImage && (
                 typeof subChild.iconImage === "string" && subChild.iconImage.startsWith("http")
                   ? <img src={subChild.iconImage} alt="item-icon" width={20} height={20} className="object-contain" />
-                  : <Image src={subChild.iconImage} alt="item-icon" />
+                  : <Image src={subChild.iconImage} alt="item-icon" width={20} height={20} />
               )}
               <Link
                 href={subChild.link ?? "#"}


### PR DESCRIPTION
Added the missing "height={20}" and "width={20}" props to submenu icons in the mobile menu. This ensures consistent icon sizing, prevents layout inconsistencies, and aligns the icons with the intended UI design.