### PR TITLE
fix: upgrade axios to 1.13.5, 0.30.3 (CVE-2026-25639)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-slot": "^1.0.2",
         "aos": "^2.3.4",
-        "axios": "^1.7.7",
+        "axios": "^1.13.5",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.390.0",
@@ -2827,13 +2827,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-slot": "^1.0.2",
     "aos": "^2.3.4",
-    "axios": "^1.7.7",
+    "axios": "^1.13.5",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.390.0",


### PR DESCRIPTION
## Summary
Upgrade axios from 1.13.2 to 1.13.5, 0.30.3 to fix CVE-2026-25639.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-25639 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-25639` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: axios: Axios affected by Denial of Service via __proto__ Key in mergeConfig

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-25639` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `package.json`
- `package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
